### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#FlycoLabelView
+# FlycoLabelView
 
-####[中文版](https://github.com/H07000223/FlycoLabelView/blob/master/README_CN.md)
+#### [中文版](https://github.com/H07000223/FlycoLabelView/blob/master/README_CN.md)
 A Simple Android LabelView.
 
-##Demo
+## Demo
 <img src="https://github.com/H07000223/FlycoLabelView/blob/master/preview.png" width="640">
 
-##Gradle
+## Gradle
 
 ```groovy
 dependencies{
@@ -14,7 +14,7 @@ dependencies{
 }
 ```
 
-##Attributes
+## Attributes
 
 |name|format|description|
 |:---:|:---:|:---:|

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,11 +1,11 @@
-#FlycoLabelView
+# FlycoLabelView
 
 一个简单的Android标签控件.
 
-##Demo
+## Demo
 <img src="https://github.com/H07000223/FlycoLabelView/blob/master/preview.png" width="640">
 
-##Gradle
+## Gradle
 
 ```groovy
 dependencies{
@@ -13,7 +13,7 @@ dependencies{
 }
 ```
 
-##Attributes
+## Attributes
 
 |name|format|description|
 |:---:|:---:|:---:|


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
